### PR TITLE
Updated the booked repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,12 +106,12 @@ RUN echo CACHEBUST=$CACHEBUST
 ARG VERSION='2.8.5'
 RUN if [ $VERSION == 'git' ]; then \
         cd /var/www/ && \
-        git clone --depth 1 https://git.code.sf.net/p/phpscheduleit/source booked; \
+	git clone --depth 1 https://github.com/americandigitalservices/KairosCalendar.git\
     else \
         oIFS="$IFS"; IFS=.; set -- $VERSION; IFS='$oIFS'; IFS='$oIFS'; \
-        cd /var/www && curl -L -Os "https://sourceforge.net/projects/phpscheduleit/files/Booked/$1.$2/booked-$VERSION.zip" && \
-        unzip "booked-$VERSION.zip" && \
-        rm "booked-$VERSION.zip"; \
+	cd /var/www && curl -L -Os "https://github.com/americandigitalservices/KairosCalendar/archive/$VERSION.zip"
+        unzip "$VERSION.zip" && \
+        rm "$VERSION.zip"; \
     fi; \
     cd /var/www/booked && \
     cp ./config/config.dist.php ./config/config.php; \


### PR DESCRIPTION
Due to the announcement on November 1st by the Booked developer, Booked can no longer be self-hosted and it's open-source nature has been moved to a SaaS-only option.

In response, the American Digital Services team forked the Booked source code to create Kairos Calendar.

Since the repositories are no longer available on SourceForce, I have updated the Dockerfile to point to the new github repo instead.